### PR TITLE
libstore: fix data race in getFileTransfer() singleton replacement

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -654,12 +654,9 @@ struct curlFileTransfer : public FileTransfer
         setup();
     }
 
-    void tearDown()
+    void tearDown(Sync<State>::WriteLock & state)
     {
-        {
-            auto state(state_.lock());
-            stopWorkerThread(state);
-        }
+        stopWorkerThread(state);
 
         workerThread.join();
 
@@ -669,13 +666,14 @@ struct curlFileTransfer : public FileTransfer
 
     ~curlFileTransfer()
     {
-        tearDown();
+        auto state(state_.lock());
+        tearDown(state);
     }
 
     void restart(Sync<State>::WriteLock state)
     {
         // Same as destructor
-        tearDown();
+        tearDown(state);
 
         // Fresh state, but reuse global mutex
         *state = State{};


### PR DESCRIPTION
Multiple threads could simultaneously observe that the singleton FileTransfer instance has quit and attempt to replace it without synchronization. This caused undefined behavior as destroying the old object while other threads might still be accessing its mutex is not allowed.

Fixed by implementing in-place restart of the FileTransfer object instead of replacing it. This avoids destroying mutexes that other threads might be waiting on or holding.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New C APIs to set log format and verbosity; improved file-transfer lifecycle with setup/restart and graceful shutdown.

* **Bug Fixes**
  * More robust transfer shutdown and worker-thread handling; enqueue guards during teardown; symlink-resolution limit; thread-safe PTY name retrieval; safer store/root path handling.

* **Documentation**
  * Content-addressed example updated to use the current build command.

* **Tests/Chores**
  * Broader shellcheck coverage and widespread quoting/safety fixes across functional tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->